### PR TITLE
Build main package instead of file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.vscode
 /release-manager-bot
+/dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@
 builds:
   - binary: release-manager-bot
     id: release-manager-bot
-    main: ./main.go
+    main: .
     goarch:
     - amd64
     goos:


### PR DESCRIPTION
Goreleaser tries to build main.go but as the main package is split into multiple
files some symbols are missing.

This change makes goreleaser build the main package instead of main.go file.