### PR TITLE
Edit expected "action" to be "opened"

### DIFF
--- a/issue_release_status.go
+++ b/issue_release_status.go
@@ -56,7 +56,7 @@ func (handler *PRCreateHandler) Handle(ctx context.Context, eventType, deliveryI
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 
 	ctx, logger := githubapp.PreparePRContext(ctx, installationID, repository, prNum)
-	if event.GetAction() != "created" {
+	if event.GetAction() != "opened" {
 		return nil
 	}
 


### PR DESCRIPTION
Apparently, when you create a new pull request, the "action" attribute in the webhook payload is "opened" instead of "created".