### PR TITLE
Upgrade to alpine:3.13.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.6 as builder
+FROM golang:1.16.0 as builder
 WORKDIR /app
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/Dockerfile-goreleaser
+++ b/Dockerfile-goreleaser
@@ -1,4 +1,4 @@
-FROM alpine:3.12.0
+FROM alpine:3.13.2
 
 RUN   apk update && \
       apk add --no-cache \

--- a/Dockerfile-goreleaser
+++ b/Dockerfile-goreleaser
@@ -1,9 +1,22 @@
-FROM alpine:3.13.2
+FROM golang:1.16.0 as builder
+WORKDIR /app
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
 
-RUN   apk update && \
-      apk add --no-cache \
-      ca-certificates
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
 
-ENTRYPOINT [ "/release-manager-bot" ]
+COPY main.go .
 
-COPY release-manager-bot /
+RUN go build -o release-manager-bot main.go
+
+FROM scratch
+WORKDIR /app
+
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /app/release-manager-bot .
+
+ENTRYPOINT [ "./release-manager-bot" ]

--- a/Dockerfile-goreleaser
+++ b/Dockerfile-goreleaser
@@ -1,22 +1,10 @@
 FROM golang:1.16.0 as builder
-WORKDIR /app
-ENV CGO_ENABLED=0
-ENV GOOS=linux
-ENV GOARCH=amd64
-
-COPY go.mod .
-COPY go.sum .
-RUN go mod download
-
-COPY main.go .
-
-RUN go build -o release-manager-bot main.go
 
 FROM scratch
 WORKDIR /app
 
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /app/release-manager-bot .
+COPY release-manager-bot /
 
 ENTRYPOINT [ "./release-manager-bot" ]


### PR DESCRIPTION
Is there any reason for why we don't use scratch here, as we do in the other `Dockerfile`?