### PR TITLE
Remove binaries from goReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,8 +15,6 @@ builds:
 
 dockers:
   - dockerfile: Dockerfile-goreleaser
-    binaries:
-      - release-manager-bot
     image_templates:
       - "quay.io/lunarway/release-manager-bot:{{ .Tag }}"
 


### PR DESCRIPTION
Currently, releases fail as the goReleaser spec is invalid. This change fixes that.